### PR TITLE
Use \Ifthispageodd instead of \ifthispageodd in template.tex

### DIFF
--- a/inst/rmarkdown/templates/saclay_thesis/skeleton/template.tex
+++ b/inst/rmarkdown/templates/saclay_thesis/skeleton/template.tex
@@ -300,7 +300,7 @@ $body$
 
 
 % 4eme de couverture
-\ifthispageodd{\newpage\thispagestyle{empty}\null\newpage}{}
+\Ifthispageodd{\newpage\thispagestyle{empty}\null\newpage}{}
 \thispagestyle{empty}
 \newgeometry{top=1.5cm, bottom=1.25cm, left=2cm, right=2cm}
 \fontfamily{rm}\selectfont


### PR DESCRIPTION
Hi @abichat 
Thanks for your work on the Paris-Saclay template, currently using it for my thesis.

Here is just a typo modification suggested by the R console  after knitting:

Usage of deprecated command `\ifthispageodd`.
The command has been renamed because of a recommendation of The LaTeX Project Team.
Please replace `\ifthispageodd` by `\Ifthispageodd`